### PR TITLE
Only display profile update message when profile action is allowed

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -275,7 +275,10 @@ class auth_plugin_authsplit extends DokuWiki_Auth_Plugin {
             );
             return false;
         }
-        msg($this->getLang('autocreated'), -1);
+        if(actionOK('profile'))
+        {
+            msg($this->getLang('autocreated'), -1);
+        }
 
         return true;
     }


### PR DESCRIPTION
Hello

In our local setup, the profile action is disabled, so your plugin shouldn't display the "update your profile" message. This little change fixes that issue by first checking if the profile action is allowed.

bug
