### PR TITLE
add fallback auth plugin option

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -75,6 +75,14 @@ class auth_plugin_authsplit extends DokuWiki_Auth_Plugin {
             $this->success = false;
             return;
         }
+        /* Use fallback auth methode? */
+        $this->use_fallback = $this->getConf('use_fallback', null);
+        if ($this->use_fallback === null) {
+            msg(sprintf($this->getLang('nocfg'), 'use_fallback'), -1);
+            $this->success = false;
+            return;
+        }
+        
 
         /* Of course, to modify login names actually BOTH auth plugins must
            support that. However, at this place we just consider the secondary
@@ -144,20 +152,31 @@ class auth_plugin_authsplit extends DokuWiki_Auth_Plugin {
                 'failed', -1, __LINE__, __FILE__
             );
             
-            $this->use_fallback = $this->getConf('use_fallback', null);
-            if ($this->use_fallback === null) {
+            if ($this->use_fallback) {
+                $this->_debug(
+                    'authsplit:checkPass(): use fallback auth plugin\'s  '.
+                    'checkPass()', -1, __LINE__, __FILE__
+                );
+            
                 if (!$this->authplugins['fallback']->checkPass($user, $pass)) {
                    $this->_debug(
                     'authsplit:checkPass(): fallback auth plugin\'s checkPass() '.
                     'failed', -1, __LINE__, __FILE__
-                );
-            return false; 
+                    );
+            			    return false; 
+                } else {
+                    $this->_debug(
+                'authsplit:checkPass(): fallback auth plugin authenticated the '.
+                'user successfully.', 1, __LINE__, __FILE__
+           );
+                }
             }
+        } else {
+            $this->_debug(
+                'authsplit:checkPass(): primary auth plugin authenticated the '.
+                'user successfully.', 1, __LINE__, __FILE__
+           );
         }
-        $this->_debug(
-            'authsplit:checkPass(): primary auth plugin authenticated the '.
-            'user successfully.', 1, __LINE__, __FILE__
-        );
 
         /* Then make sure that the secondary auth plugin also knows about the
            user. */

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,3 +9,4 @@ $conf['primary_authplugin']   = 'authplain';
 $conf['secondary_authplugin'] = 'authplain';
 $conf['autocreate_users']     = 0;
 $conf['debug']                = 0;
+$conf['fallback_authplain']   = 0;

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,4 +9,5 @@ $conf['primary_authplugin']   = 'authplain';
 $conf['secondary_authplugin'] = 'authplain';
 $conf['autocreate_users']     = 0;
 $conf['debug']                = 0;
-$conf['fallback_authplain']   = 0;
+$conf['use_fallback']         = 0;
+$conf['fallback_authplugin']  = 'authplain';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -20,3 +20,4 @@ $meta['primary_authplugin']   = array('authtype_nosplit', '_cautionList' => arra
 $meta['secondary_authplugin'] = array('authtype_nosplit', '_cautionList' => array('plugin____authsplit____secondary_authplugin' => 'danger'));
 $meta['autocreate_users']     = array('onoff');
 $meta['debug']                = array('onoff');
+$meta['fallback_authplain']   = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -20,4 +20,5 @@ $meta['primary_authplugin']   = array('authtype_nosplit', '_cautionList' => arra
 $meta['secondary_authplugin'] = array('authtype_nosplit', '_cautionList' => array('plugin____authsplit____secondary_authplugin' => 'danger'));
 $meta['autocreate_users']     = array('onoff');
 $meta['debug']                = array('onoff');
-$meta['fallback_authplain']   = array('onoff');
+$meta['fallback_authplugin']  = array('authtype_nosplit', '_cautionList' => array('plugin____authsplit____secondary_authplugin' => 'danger'));
+$meta['use_fallback']         = array('onoff');


### PR DESCRIPTION
Add the possibility to use a "third" auth plugin as a fallback for the primary auth plugin.

In our wiki we use authimap2 as primary auth plugin. But some dokuwiki user has no email adress. So the primary auth checkpass failed and then the fallback plugin (we use authplain) will fire checkpass(). The login of the dokuwiki user with no email adress are succefully. 