### PR TITLE
be compatible with igor

### DIFF
--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,7 +8,7 @@
 /* Define a custom "authtype" class that does not show authsplit */
 if (!class_exists('setting_authtype_nosplit')) {
     class setting_authtype_nosplit extends setting_authtype {
-        function initialize($default, $local, $protected) {
+        function initialize($default=null, $local=null, $protected=null) {
             parent::initialize($default, $local, $protected);
 
             $this->_choices = array_diff($this->_choices, array("authsplit"));


### PR DESCRIPTION
Hi,

Thanks for this very useful plugin.

With Igor, method compatibility is very strict. When defining a method in a child class, parameters must be exactly the same as the parent method's.

Entering admin => configuration settings makes DW die with this error message :

> /var/www/lib/plugins/authsplit/conf/metadata.php(11)	dokuwiki\Exception\FatalException: Declaration of setting_authtype_nosplit::initialize($default, $local, $protected) must be compatible with dokuwiki\plugin\config\core\Setting\SettingAuthtype::initialize($default = null, $local = null, $protected = null)
  #0 [internal function]: dokuwiki\ErrorHandler::fatalShutdown()
  #1 {main}

This small PR solves the problem.

