### PR TITLE
fix compatibility issue with deprecated setting class

### DIFF
--- a/Setting.php
+++ b/Setting.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace dokuwiki\plugin\authsplit;
+
+use dokuwiki\plugin\config\core\Setting\SettingAuthtype;
+
+/**
+ *  Defines a custom "authtype" class that does not show authsplit
+ */
+class Setting extends SettingAuthtype
+{
+    /** @inheritdoc */
+    function initialize($default = null, $local = null, $protected = null)
+    {
+        parent::initialize($default, $local, $protected);
+
+        $this->choices = array_diff($this->choices, ['authsplit']);
+    }
+}

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,19 +5,8 @@
  * @author Pieter Hollants <pieter@hollants.com>
  */
 
-/* Define a custom "authtype" class that does not show authsplit */
-if (!class_exists('setting_authtype_nosplit')) {
-    class setting_authtype_nosplit extends setting_authtype {
-        function initialize($default=null, $local=null, $protected=null) {
-            parent::initialize($default, $local, $protected);
-
-            $this->_choices = array_diff($this->_choices, array("authsplit"));
-        }
-    }
-}
-
-$meta['primary_authplugin']       = array('authtype_nosplit', '_cautionList' => array('plugin____authsplit____primary_authplugin' => 'danger'));
-$meta['secondary_authplugin']     = array('authtype_nosplit', '_cautionList' => array('plugin____authsplit____secondary_authplugin' => 'danger'));
+$meta['primary_authplugin']       = array(\dokuwiki\plugin\authsplit\Setting::class, '_caution' => 'danger');
+$meta['secondary_authplugin']     = array(\dokuwiki\plugin\authsplit\Setting::class, '_caution' => 'danger');
 $meta['autocreate_users']         = array('onoff');
 $meta['username_caseconversion']  = array('multichoice', '_choices' => array('None', 'To uppercase', 'To lowercase'));
 $meta['debug']                    = array('onoff');


### PR DESCRIPTION
The plugin provided a class inheriting from a DokuWiki setting class that no longer exists. This changes it to use the proper new class and also makes use of namespaced autoloading instead of squeezing the class into the metadata file.

This fixes a fatal error on Librarian.